### PR TITLE
fix module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/carlmjohnson/requests
+module github.com/earthboundkid/requests
 
 go 1.20
 


### PR DESCRIPTION
Owner's username has changed on GitHub

```
$ go get github.com/earthboundkid/requests
go: downloading github.com/earthboundkid/requests v0.23.5
go: github.com/earthboundkid/requests@upgrade (v0.23.5) requires github.com/earthboundkid/requests@v0.23.5: parsing go.mod:
        module declares its path as: github.com/carlmjohnson/requests
                but was required as: github.com/earthboundkid/requests
```