### PR TITLE
feat(handler): implement duplicate read closer for request body

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -1,8 +1,10 @@
 package requests_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -31,4 +33,38 @@ func BenchmarkBuilder_ToFile(b *testing.B) {
 			Fetch(context.Background())
 		be.NilErr(b, err)
 	}
+}
+
+// TestChainHandlers tests the ChainHandlers function.
+func TestChainHandlers(t *testing.T) {
+	type Common struct {
+		ID int `json:"id"`
+	}
+
+	type Book struct {
+		Common
+		Name string `json:"name"`
+	}
+
+	var (
+		book   Book
+		common Common
+		str    string
+	)
+
+	handler := requests.ChainHandlers(
+		requests.ToJSON(&common),
+		requests.ToJSON(&book),
+		requests.ToString(&str),
+	)
+
+	err := handler(&http.Response{
+		Body: io.NopCloser(bytes.NewReader([]byte(`{"id":1, "name":"孙子兵法"}`))),
+	})
+
+	be.NilErr(t, err)
+	be.Equal(t, 1, common.ID)
+	be.Equal(t, 1, book.ID)
+	be.Equal(t, "孙子兵法", book.Name)
+	be.Equal(t, `{"id":1, "name":"孙子兵法"}`, str)
 }


### PR DESCRIPTION
This change introduces a utility function `dupReadCloser` that allows duplicating the incoming request body reader. It is now used in the request handling loop to ensure that the request body can be consumed by multiple handlers or middleware without losing the original data.